### PR TITLE
Integrate Ollama plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ path to your project)
 cd /path/to/your/project/
 nvim ./
 ```
+
+## Ollama integration
+
+This configuration includes the [nomnivore/ollama.nvim](https://github.com/nomnivore/ollama.nvim) plugin.
+After launching Neovim you can start a chat session with `<leader>oo`.
+The plugin also registers an `ollama` completion source for `nvim-cmp`.

--- a/lua/tristonc/core/keymaps.lua
+++ b/lua/tristonc/core/keymaps.lua
@@ -24,3 +24,6 @@ keymap.set("n", "<leader>tx", "<cmd>tabclose<CR>", { desc = "Close current tab" 
 keymap.set("n", "<leader>tn", "<cmd>tabn<CR>", { desc = "Go to next tab" }) --  go to next tab
 keymap.set("n", "<leader>tp", "<cmd>tabp<CR>", { desc = "Go to previous tab" }) --  go to previous tab
 keymap.set("n", "<leader>tf", "<cmd>tabnew %<CR>", { desc = "Open current buffer in new tab" }) --  move current buffer to new tab
+
+-- Ollama
+keymap.set("n", "<leader>oo", "<cmd>OllamaChat<CR>", { desc = "Ollama Chat" })

--- a/lua/tristonc/plugins/init.lua
+++ b/lua/tristonc/plugins/init.lua
@@ -1,4 +1,5 @@
 return {
   "nvim-lua/plenary.nvim", -- lua functions that many plugins use
   "christoomey/vim-tmux-navigator", -- tmux & split window navigation
+  { import = "tristonc.plugins.ollama" },
 }

--- a/lua/tristonc/plugins/nvim-cmp.lua
+++ b/lua/tristonc/plugins/nvim-cmp.lua
@@ -48,6 +48,7 @@ return {
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
+        { name = "ollama" }, -- ollama completions
       }),
 
       -- configure lspkind for vs-code like pictograms in completion menu

--- a/lua/tristonc/plugins/ollama.lua
+++ b/lua/tristonc/plugins/ollama.lua
@@ -1,0 +1,8 @@
+return {
+  "nomnivore/ollama.nvim",
+  dependencies = { "nvim-lua/plenary.nvim" },
+  opts = {},
+  keys = {
+    { "<leader>oo", "<cmd>OllamaChat<CR>", desc = "Ollama Chat" },
+  },
+}


### PR DESCRIPTION
## Summary
- add `nomnivore/ollama.nvim` plugin configuration
- expose Ollama completion source in nvim-cmp
- map `<leader>oo` to start an Ollama chat
- document the feature in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c8a2373588323b7cf611bbc90c2ea